### PR TITLE
ginkgo: add missing include

### DIFF
--- a/var/spack/repos/builtin/packages/ginkgo/package.py
+++ b/var/spack/repos/builtin/packages/ginkgo/package.py
@@ -87,6 +87,9 @@ class Ginkgo(CMakePackage, CudaPackage, ROCmPackage):
     patch("1.4.0_dpcpp_use_old_standard.patch", when="+oneapi @master")
     patch("1.4.0_dpcpp_use_old_standard.patch", when="+oneapi @1.4.0")
 
+    # Add missing include statement
+    patch("thrust-count-header.patch", when="+rocm @1.5.0:")
+
     def setup_build_environment(self, env):
         spec = self.spec
         if "+oneapi" in spec:

--- a/var/spack/repos/builtin/packages/ginkgo/thrust-count-header.patch
+++ b/var/spack/repos/builtin/packages/ginkgo/thrust-count-header.patch
@@ -1,0 +1,12 @@
+diff --git a/hip/distributed/partition_kernels.hip.cpp b/hip/distributed/partition_kernels.hip.cpp
+index 94d167a00..9422b70d8 100644
+--- a/hip/distributed/partition_kernels.hip.cpp
++++ b/hip/distributed/partition_kernels.hip.cpp
+@@ -33,6 +33,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ #include "core/distributed/partition_kernels.hpp"
+ 
+ 
++#include <thrust/count.h>
+ #include <thrust/device_ptr.h>
+ #include <thrust/execution_policy.h>
+ #include <thrust/iterator/zip_iterator.h>


### PR DESCRIPTION
This was the only change I needed for:

    spack install ginkgo@1.5.0 +rocm amdgpu_target=gfx906:xnack- ^rocsolver ~optimal amdgpu_target=gfx906:xnack- ^rocsparse amdgpu_target=gfx906:xnack-
